### PR TITLE
Configure native host path and permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,17 @@ This template should help get you started developing with Svelte in WXT.
 ## Recommended IDE Setup
 
 [VS Code](https://code.visualstudio.com/) + [Svelte](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).
+
+## Native Host Setup
+
+This project communicates with a Python native messaging host. To install it:
+
+1. Make the script executable:
+   ```bash
+   chmod +x native_host/selector_logger.py
+   ```
+2. Copy `native_host/com.pfahlr.selectorlogger.json` to your browser's native-messaging hosts directory and update the `path` if needed.
+
+The manifest now references `selector_logger.py` by relative path so the host can be installed in any location.
+
 # passivepilFRrr

--- a/original_project/selector-logger/manifest.json
+++ b/original_project/selector-logger/manifest.json
@@ -7,12 +7,12 @@
     "default_title": "Selector Logger",
     "default_popup": "popup.html"
   },
-  "permissions": ["storage", "scripting", "activeTab"],
+  "permissions": ["storage", "scripting", "activeTab", "nativeMessaging"],
   "host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "background.ts"
   },
-  "optional_permissions": ["downloads", "nativeMessaging"],
+  "optional_permissions": ["downloads"],
   "browser_specific_settings": {
   "gecko": { "id": "selectorlogger@pfahlr" }
    }

--- a/original_project/selector-logger/native_host/com.pfahlr.selectorlogger.json
+++ b/original_project/selector-logger/native_host/com.pfahlr.selectorlogger.json
@@ -1,7 +1,7 @@
 {
   "name": "com.pfahlr.selectorlogger",
   "description": "Native host for Selector Logger",
-  "path": "/home/rick/Development/firefox-plugins/selector-logger/native_host/selector_logger.py",
+  "path": "selector_logger.py",
   "type": "stdio",
   "allowed_origins": ["chrome-extension://jppakgbidmimbpnhpmgaakglhddchgmk/"],
   "allowed_extensions":  ["selectorlogger@pfahlr"]

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "dev": "wxt",
     "build": "wxt build",
-    "lint": "eslint .",
+    "zip": "wxt zip",
     "typecheck": "tsc --noEmit",
-    "test": "npm run lint && npm run typecheck"
+    "lint": "eslint .",
+    "format": "eslint . --fix",
+    "test": "pnpm lint && pnpm typecheck"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,4 +5,14 @@ export default defineConfig({
     '~': 'src',
     '#imports': '.wxt/imports',
   },
+  imports: {
+    eslintrc: {
+      enabled: true,
+    },
+  },
+  manifest: {
+    permissions: ['storage', 'scripting', 'activeTab', 'nativeMessaging'],
+    optional_permissions: ['downloads'],
+    host_permissions: ['<all_urls>'],
+  },
 });


### PR DESCRIPTION
## Summary
- move nativeMessaging permission into main manifest and expose through WXT config
- point native host manifest to relative Python script path and document setup steps
- add missing dev, zip, and format scripts

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfa9edefa4832c9e61b60701042e65