### PR TITLE
Add extension integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "passivepilfrrr",
   "version": "0.1.0",
   "type": "module",
+  "imports": {
+    "#imports": "./test/stubs/imports.ts"
+  },
   "scripts": {
     "dev": "wxt",
     "build": "wxt build",

--- a/selector_logger.test.ts
+++ b/selector_logger.test.ts
@@ -1,0 +1,30 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import fs from 'node:fs/promises'
+
+function sendAndWait(proc: any, obj: any) {
+  return new Promise(resolve => {
+    proc.stdout.once('readable', () => {
+      const len = proc.stdout.read(4).readUInt32LE(0)
+      const resp = proc.stdout.read(len)
+      resolve(JSON.parse(resp.toString()))
+    })
+    const body = Buffer.from(JSON.stringify(obj))
+    const header = Buffer.alloc(4)
+    header.writeUInt32LE(body.length, 0)
+    proc.stdin.write(Buffer.concat([header, body]))
+  })
+}
+
+test('selector_logger appends lines to file', async () => {
+  const proc = spawn('python3', ['selector_logger.py'])
+  const logPath = path.join(tmpdir(), 'selector_logger_test.log')
+  await fs.rm(logPath, { force: true })
+  await sendAndWait(proc, { op: 'append', path: logPath, lines: ['a', 'b'] })
+  proc.kill()
+  const content = await fs.readFile(logPath, 'utf8')
+  assert.equal(content.trim(), 'a\nb')
+})

--- a/src/entrypoints/background/index.test.ts
+++ b/src/entrypoints/background/index.test.ts
@@ -1,0 +1,82 @@
+import { test, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { storage } from '../../../test/stubs/imports.ts'
+import { visitedItem, stateItem } from '../../lib/utils/storage.ts'
+import fs from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+let onUpdated: any
+let sendCount: number
+
+function setupChrome() {
+  sendCount = 0
+  globalThis.chrome = {
+    tabs: {
+      onUpdated: { addListener: (cb: any) => { onUpdated = cb } },
+      sendMessage: async () => { sendCount++ },
+    },
+    action: {
+      setBadgeText: () => {},
+      setBadgeBackgroundColor: () => {},
+    },
+    runtime: {
+      id: 'x',
+      connectNative: () => ({
+        onDisconnect: { addListener: () => {} },
+        onMessage: { addListener: () => {} },
+        postMessage: () => {},
+      }),
+      onInstalled: { addListener: () => {} },
+      onStartup: { addListener: () => {} },
+      lastError: undefined,
+    },
+    storage: { onChanged: { addListener: () => {} } },
+  } as any
+  globalThis.browser = { runtime: { id: 'x' } } as any
+  globalThis.defineBackground = (fn: any) => fn()
+}
+
+beforeEach(() => {
+  storage._store.clear()
+  setupChrome()
+})
+
+  test('autoRun runs collectors when enabled', async () => {
+  const messagingMod = await import('../../lib/messaging.ts')
+  messagingMod.messaging.sendMessage = async () => ({ ok: true })
+  messagingMod.messaging.onMessage = () => () => {}
+
+  // state: autoRun enabled
+    await stateItem.setValue({
+      rows: [{ enabled: true, value: '.a' }],
+      autoRun: true,
+      skipVisited: true,
+      enableNative: false,
+      filePath: '',
+    })
+  await visitedItem.setValue({ urls: [] })
+
+  const src = fs
+    .readFileSync(path.join(process.cwd(), 'src/entrypoints/background/index.ts'), 'utf8')
+    .replace(/from '~\/([^']+)'/g, (_m, p) => `from '${pathToFileURL(path.join(process.cwd(), 'src', p + '.ts')).href}'`)
+  const temp = path.join(tmpdir(), 'background.test.tmp.ts')
+  fs.writeFileSync(temp, src)
+  await import(pathToFileURL(temp).href)
+  fs.unlinkSync(temp)
+  await onUpdated(1, { status: 'complete' }, { id: 1, url: 'https://a.com' })
+  assert.equal(sendCount, 1)
+
+    // disable autoRun
+    await stateItem.setValue({
+      rows: [],
+      autoRun: false,
+      skipVisited: true,
+      enableNative: false,
+      filePath: '',
+    })
+  await onUpdated(2, { status: 'complete' }, { id: 2, url: 'https://b.com' })
+  assert.equal(sendCount, 1)
+
+})

--- a/src/lib/MatchForm.test.ts
+++ b/src/lib/MatchForm.test.ts
@@ -1,0 +1,12 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const file = fs.readFileSync(path.join(process.cwd(), 'src/lib/MatchForm.svelte'), 'utf8')
+
+test('popup displays configuration form', () => {
+  assert.match(file, /<h1>Selector Logger<\/h1>/)
+  assert.match(file, />Run<\/button>/)
+  assert.match(file, /Auto-run on page load/)
+})

--- a/src/lib/utils/visited.test.ts
+++ b/src/lib/utils/visited.test.ts
@@ -1,0 +1,14 @@
+import { test, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { visitedItem } from './storage.ts'
+
+beforeEach(async () => {
+  await visitedItem.setValue({ urls: [] })
+})
+
+test('visited storage records unique urls', async () => {
+  const url = 'https://example.com'
+  await visitedItem.setValue({ urls: [url] })
+  const v1 = await visitedItem.getValue()
+  assert.deepEqual(v1.urls, [url])
+})

--- a/test/stubs/imports.ts
+++ b/test/stubs/imports.ts
@@ -1,0 +1,16 @@
+const store = new Map<string, any>()
+
+export const storage = {
+  _store: store,
+  defineItem<T>(key: string, { fallback }: { fallback: T }) {
+    if (!store.has(key)) store.set(key, fallback)
+    return {
+      async getValue() {
+        return store.has(key) ? store.get(key) : fallback
+      },
+      async setValue(v: T) {
+        store.set(key, v)
+      },
+    }
+  },
+}


### PR DESCRIPTION
## Summary
- add package import alias for test stubs
- test popup markup, autoRun logic, native host integration and visited storage

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_68c3bde52a28832cb51de0d3c5e01264