### PR TITLE
fix test globals for browser

### DIFF
--- a/src/entrypoints/background/index.test.ts
+++ b/src/entrypoints/background/index.test.ts
@@ -7,6 +7,13 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
+declare global {
+  // wxt injects these globals in the real extension environment
+  // declare here for tests and type checking
+  // eslint-disable-next-line no-var
+  var browser: any
+}
+
 let onUpdated: any
 let sendCount: number
 


### PR DESCRIPTION
## Summary
- declare global `browser` in background tests for TypeScript

## Testing
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c3cc5c1774832c89119ca17537aacc