### PR TITLE
Associate log label with textarea

### DIFF
--- a/src/lib/MatchForm.svelte
+++ b/src/lib/MatchForm.svelte
@@ -160,7 +160,7 @@
     <div class="status">{nativeStatus}</div>
   </details>
 
-  <label class="loglabel">Log</label>
-  <textarea rows="10" spellcheck="false" bind:value={log} readonly></textarea>
+  <label class="loglabel" for="log">Log</label>
+  <textarea id="log" rows="10" spellcheck="false" bind:value={log} readonly></textarea>
 </div>
 

--- a/src/lib/MatchForm.test.ts
+++ b/src/lib/MatchForm.test.ts
@@ -9,4 +9,6 @@ test('popup displays configuration form', () => {
   assert.match(file, /<h1>Selector Logger<\/h1>/)
   assert.match(file, />Run<\/button>/)
   assert.match(file, /Auto-run on page load/)
+  assert.match(file, /<label[^>]*for="log"[^>]*>Log<\/label>/)
+  assert.match(file, /<textarea[^>]*id="log"/)
 })


### PR DESCRIPTION
## Summary
- ensure the log textarea is labeled for accessibility
- test that popup markup includes matching label and textarea id

## Testing
- `pnpm test`
- `CI=1 pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c3d624b090832c9554e7ade587edb5