### PR TITLE
fix: enable adding rows in match form

### DIFF
--- a/src/lib/MatchForm.svelte
+++ b/src/lib/MatchForm.svelte
@@ -25,14 +25,18 @@
 
   function addRow(i?: number) {
     const row: Row = { enabled: true, value: '' };
-    if (i == null) rows.push(row);
-    else rows.splice(i + 1, 0, row);
+    if (i == null) rows = [...rows, row];
+    else {
+      rows.splice(i + 1, 0, row);
+      rows = [...rows];
+    }
     persist();
   }
 
   function removeRow(i: number) {
     rows.splice(i, 1);
     if (!rows.length) rows.push({ enabled: true, value: '' });
+    rows = [...rows];
     persist();
   }
 

--- a/src/lib/MatchForm.test.ts
+++ b/src/lib/MatchForm.test.ts
@@ -12,3 +12,8 @@ test('popup displays configuration form', () => {
   assert.match(file, /<label[^>]*for="log"[^>]*>Log<\/label>/)
   assert.match(file, /<textarea[^>]*id="log"/)
 })
+
+test('rows are reassigned on add/remove', () => {
+  assert.match(file, /function addRow[\s\S]*rows\s*=\s*\[/)
+  assert.match(file, /function removeRow[\s\S]*rows\s*=\s*\[/)
+})


### PR DESCRIPTION
## Summary
- ensure add/remove row functions reassign array for Svelte reactivity
- add unit test confirming rows are reassigned

## Testing
- `node --experimental-strip-types --test src/lib/MatchForm.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` *(fails: Timed out after waiting 30000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e87fbc90832cb55b8b8f36a43415