### PR TITLE
docs: document Puppeteer system dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,19 @@ This project communicates with a Python native messaging host. To install it:
   The manifest now references `selector_logger.py` by relative path so the host can be installed in any location.
 
   The manifest references `../selector_logger.py` so the host can be installed alongside this repository in any location.
+
+## Puppeteer Setup
+
+This project uses [Puppeteer](https://pptr.dev/) for end-to-end tests. Chromium requires several system libraries to run. On Debian/Ubuntu, install them with:
+
+```bash
+sudo apt-get install -y libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
+  libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libasound2
+```
+
+After installing the libraries, download the Chromium binary used by Puppeteer:
+
+```bash
+pnpm exec puppeteer browsers install
+```
+


### PR DESCRIPTION
## Summary
- add README section on required system libraries for Puppeteer
- document how to download Chromium with `pnpm exec puppeteer browsers install`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:e2e`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3f27ddcd0832ca5e4259942553056